### PR TITLE
Fix 2 command issues

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -157,7 +157,7 @@ function awards.disable(name)
 end
 
 function awards.clear_player(name)
-	awards.players[name] = nil
+	awards.players[name] = {}
 end
 
 -- This function is called whenever a target condition is met.

--- a/chat_commands.lua
+++ b/chat_commands.lua
@@ -36,16 +36,6 @@ minetest.register_chatcommand("awards", {
 	end
 })
 
-minetest.register_chatcommand("cawards", {
-	params = "",
-	description = "awards: list awards in chat",
-	func = function(name, param)
-		awards.show_to(name, name, nil, true)
-		minetest.chat_send_player(name, "/cawards has been depreciated," ..
-				" use /awards c instead")
-	end
-})
-
 minetest.register_chatcommand("awd", {
 	params = "award name",
 	description = "awd: Details of awd gotten",


### PR DESCRIPTION
Problem 1: If you opened the awards formspec after `/awards clear`, it crashed. This PR fixes this.
Problem 2: `/cawards` is useless and old and only clutters the output of `/help all`. This PR removes this command for real.