### PR TITLE
Fix bugs when mod is run outside of Minetest Game

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -463,9 +463,13 @@ function awards.show_to(name, to, sid, text)
 		if sid == nil or sid < 1 then
 			sid = 1
 		end
+		local deco = ""
+		if minetest.global_exists("default") then
+			deco = default.gui_bg .. default.gui_bg_img
+		end
 		-- Show formspec to user
 		minetest.show_formspec(to,"awards:awards",
-			"size[11,5]" .. default.gui_bg .. default.gui_bg_img ..
+			"size[11,5]" .. deco ..
 			awards.getFormspec(name, to, sid))
 	end
 end

--- a/init.lua
+++ b/init.lua
@@ -70,16 +70,18 @@ end
 
 -- This award can't be part of Unified Inventory, it would make a circular dependency
 if minetest.get_modpath("unified_inventory") then
-	awards.register_achievement("awards_ui_bags", {
-		title = S("Backpacker"),
-		description = S("Craft 4 large bags."),
-		icon = "awards_ui_bags.png",
-		trigger = {
-			type = "craft",
-			item = "unified_inventory:bag_large",
-			target = 4
-		}
-	})
+	if minetest.get_all_craft_recipes("unified_inventory:bag_large") ~= nil then
+		awards.register_achievement("awards_ui_bags", {
+			title = S("Backpacker"),
+			description = S("Craft 4 large bags."),
+			icon = "awards_ui_bags.png",
+			trigger = {
+				type = "craft",
+				item = "unified_inventory:bag_large",
+				target = 4
+			}
+		})
+	end
 end
 
 if minetest.get_modpath("fire") then


### PR DESCRIPTION
Bugs fixed:
- Impossible Backpacker award if `wool` mod is missing. Backpacker award is now removed when bags can not be crafted (happens if mod is run outside of Minetest Game)
- Fix crash when mod is run outside of Minetest Game (game hard-depended on default table to build the formspec)