### PR TITLE
Fix mod not working with mod security and intllib

### DIFF
--- a/chat_commands.lua
+++ b/chat_commands.lua
@@ -15,9 +15,8 @@
 --
 
 local S
-if (intllib) then
-	dofile(minetest.get_modpath("intllib").."/intllib.lua")
-	S = intllib.Getter(minetest.get_current_modname())
+if minetest.get_modpath("intllib") then
+	S = intllib.Getter()
 else
 	S = function ( s ) return s end
 end

--- a/init.lua
+++ b/init.lua
@@ -16,9 +16,8 @@
 
 
 local S
-if (intllib) then
-	dofile(minetest.get_modpath("intllib").."/intllib.lua")
-	S = intllib.Getter(minetest.get_current_modname())
+if minetest.get_modpath("intllib") then
+	S = intllib.Getter()
 else
 	S = function ( s ) return s end
 end

--- a/sfinv.lua
+++ b/sfinv.lua
@@ -1,8 +1,7 @@
 if minetest.get_modpath("sfinv") then
 	local S
-	if (intllib) then
-		dofile(minetest.get_modpath("intllib").."/intllib.lua")
-		S = intllib.Getter(minetest.get_current_modname())
+	if minetest.get_modpath("intllib") then
+		S = intllib.Getter()
 	else
 		S = function ( s ) return s end
 	end

--- a/triggers.lua
+++ b/triggers.lua
@@ -15,9 +15,8 @@
 --
 
 local S
-if (intllib) then
-	dofile(minetest.get_modpath("intllib").."/intllib.lua")
-	S = intllib.Getter(minetest.get_current_modname())
+if minetest.get_modpath("intllib") then
+	S = intllib.Getter()
 else
 	S = function ( s ) return s end
 end

--- a/unified_inventory.lua
+++ b/unified_inventory.lua
@@ -1,8 +1,7 @@
 if minetest.get_modpath("unified_inventory") ~= nil then
 	local S
-	if (intllib) then
-		dofile(minetest.get_modpath("intllib").."/intllib.lua")
-		S = intllib.Getter(minetest.get_current_modname())
+	if minetest.get_modpath("intllib") then
+		S = intllib.Getter()
 	else
 		S = function ( s ) return s end
 	end


### PR DESCRIPTION
If you start this mod with mod security AND `intllib` enabled, the mod does not work and Minetest refuses to start the game.
This is because of outdated `intllib` boilerplate code:

    dofile(minetest.get_modpath("intllib").."/intllib.lua")

This PR updates all `intllib` boilerplates and fixes the bug.