### PR TITLE
Replace deprecated 'setting_getbool' with 'settings:get_bool'

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -95,7 +95,7 @@ if minetest.get_modpath("fire") then
 			target = 8
 		}
 	})
-	if minetest.setting_getbool("disable_fire") ~= true then
+	if minetest.settings:get_bool("disable_fire") ~= true then
 		awards.register_achievement("awards_firefighter", {
 			title = S("Firefighter"),
 			description = S("Put out 1000 fires."),


### PR DESCRIPTION
May not want to merge this until after 0.4.16 release, as the new ['settings' object calls][l_settings] are not available in 0.4.15.

[l_settings]: https://github.com/minetest/minetest/blob/43d1f375d18a2fbc547a9b4f23d1354d645856ca/src/script/lua_api/l_settings.cpp#L267